### PR TITLE
wheel is required to compile in python 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -403,7 +403,7 @@ def run_setup(extensions):
         else:
             sys.stderr.write("Bypassing Cython setup requirement\n")
 
-    dependencies = ['six >=1.9']
+    dependencies = ['six >=1.9', 'wheel >=0.34.2']
 
     if not PY3:
         dependencies.append('futures')


### PR DESCRIPTION
Create a new python 3.8 virtualenv and try installing:
```
$ pip install yb-cassandra-driver
Collecting yb-cassandra-driver
  Downloading yb-cassandra-driver-3.13.0.1.tar.gz (224 kB)
     |████████████████████████████████| 224 kB 678 kB/s 
Requirement already satisfied: six>=1.9 in /home/guru/env/yugabyte-db-dorian3.8/lib/python3.8/site-packages (from yb-cassandra-driver) (1.15.0)
Using legacy setup.py install for yb-cassandra-driver, since package 'wheel' is not installed.
Installing collected packages: yb-cassandra-driver
    Running setup.py install for yb-cassandra-driver ... error
    ERROR: Command errored out with exit status 1:
     command: /home/guru/env/yugabyte-db-dorian3.8/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-4yli9a2_/yb-cassandra-driver/setup.py'"'"'; __file__='"'"'/tmp/pip-install-4yli9a2_/yb-cassandra-driver/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-atu6lzqe/install-record.txt --single-version-externally-managed --compile --install-headers /home/guru/env/yugabyte-db-dorian3.8/include/site/python3.8/yb-cassandra-driver
         cwd: /tmp/pip-install-4yli9a2_/yb-cassandra-driver/
    Complete output (47 lines):
    WARNING: The wheel package is not available.
      ERROR: Command errored out with exit status 1:
       command: /home/guru/env/yugabyte-db-dorian3.8/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-wheel-5_le_th9/Cython/setup.py'"'"'; __file__='"'"'/tmp/pip-wheel-5_le_th9/Cython/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-p1quxjy0
           cwd: /tmp/pip-wheel-5_le_th9/Cython/
      Complete output (7 lines):
      Unable to find pgen, not compiling formal grammar.
      usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
         or: setup.py --help [cmd1 cmd2 ...]
         or: setup.py --help-commands
         or: setup.py cmd --help
    
      error: invalid command 'bdist_wheel'
      ----------------------------------------
      ERROR: Failed building wheel for Cython
    ERROR: Failed to build one or more wheels
    Traceback (most recent call last):
      File "/home/guru/env/yugabyte-db-dorian3.8/lib/python3.8/site-packages/setuptools/installer.py", line 128, in fetch_build_egg
        subprocess.check_call(cmd)
      File "/usr/lib/python3.8/subprocess.py", line 364, in check_call
        raise CalledProcessError(retcode, cmd)
    subprocess.CalledProcessError: Command '['/home/guru/env/yugabyte-db-dorian3.8/bin/python', '-m', 'pip', '--disable-pip-version-check', 'wheel', '--no-deps', '-w', '/tmp/tmpb3xh2bqb', '--quiet', 'Cython!=0.25,<0.28,>=0.20']' returned non-zero exit status 1.
    
    During handling of the above exception, another exception occurred:
    
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-4yli9a2_/yb-cassandra-driver/setup.py", line 442, in <module>
        run_setup(None)
      File "/tmp/pip-install-4yli9a2_/yb-cassandra-driver/setup.py", line 411, in run_setup
        setup(
      File "/home/guru/env/yugabyte-db-dorian3.8/lib/python3.8/site-packages/setuptools/__init__.py", line 160, in setup
        _install_setup_requires(attrs)
      File "/home/guru/env/yugabyte-db-dorian3.8/lib/python3.8/site-packages/setuptools/__init__.py", line 155, in _install_setup_requires
        dist.fetch_build_eggs(dist.setup_requires)
      File "/home/guru/env/yugabyte-db-dorian3.8/lib/python3.8/site-packages/setuptools/dist.py", line 695, in fetch_build_eggs
        resolved_dists = pkg_resources.working_set.resolve(
      File "/home/guru/env/yugabyte-db-dorian3.8/lib/python3.8/site-packages/pkg_resources/__init__.py", line 781, in resolve
        dist = best[req.key] = env.best_match(
      File "/home/guru/env/yugabyte-db-dorian3.8/lib/python3.8/site-packages/pkg_resources/__init__.py", line 1066, in best_match
        return self.obtain(req, installer)
      File "/home/guru/env/yugabyte-db-dorian3.8/lib/python3.8/site-packages/pkg_resources/__init__.py", line 1078, in obtain
        return installer(requirement)
      File "/home/guru/env/yugabyte-db-dorian3.8/lib/python3.8/site-packages/setuptools/dist.py", line 754, in fetch_build_egg
        return fetch_build_egg(self, req)
      File "/home/guru/env/yugabyte-db-dorian3.8/lib/python3.8/site-packages/setuptools/installer.py", line 130, in fetch_build_egg
        raise DistutilsError(str(e))
    distutils.errors.DistutilsError: Command '['/home/guru/env/yugabyte-db-dorian3.8/bin/python', '-m', 'pip', '--disable-pip-version-check', 'wheel', '--no-deps', '-w', '/tmp/tmpb3xh2bqb', '--quiet', 'Cython!=0.25,<0.28,>=0.20']' returned non-zero exit status 1.
    ----------------------------------------
ERROR: Command errored out with exit status 1: /home/guru/env/yugabyte-db-dorian3.8/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-4yli9a2_/yb-cassandra-driver/setup.py'"'"'; __file__='"'"'/tmp/pip-install-4yli9a2_/yb-cassandra-driver/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-atu6lzqe/install-record.txt --single-version-externally-managed --compile --install-headers /home/guru/env/yugabyte-db-dorian3.8/include/site/python3.8/yb-cassandra-driver Check the logs for full command output.
```
**Reason**: `Using legacy setup.py install for yb-cassandra-driver, since package 'wheel' is not installed.` 

**Fix:** Add `wheel` to requirements. Then it compiles.
