### PR TITLE
Fix for "[YCQL] describe keyspace <keyspace_name> throws error #16530"

### DIFF
--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -1457,7 +1457,7 @@ class TableMetadataV3(TableMetadata):
     compaction_options = {}
 
     option_maps = [
-        'compaction', 'compression', 'caching',
+        'compaction', 'compression', 'caching', 'transactions',
         'nodesync'  # added DSE 6.0
     ]
 


### PR DESCRIPTION
### Problem Statement 

Github Link: [#16530](https://github.com/yugabyte/yugabyte-db/issues/16530)
Jira Link: [DB-5926](https://yugabyte.atlassian.net/browse/DB-5926)
#### Description
```
# ycqlsh 127.0.0.1   
Connected to local cluster at 127.0.0.1:9042.
[ycqlsh 5.0.1 | Cassandra 3.9-SNAPSHOT | CQL spec 3.4.2 | Native protocol v4]
Use HELP for help.
ycqlsh> describe keyspaces;

system_schema  system_auth  system

ycqlsh> describe keyspace system;

'OrderedMapSerializedKey' object has no attribute 'replace'
ycqlsh> 
```
## Fix

#5 removed `'transactions'` from `option_maps` (Since apache Cassandra does not has TRANSACTIONS we need to add this for YCQL, was added before in this [commit](https://github.com/yugabyte/cassandra-python-driver/commit/743d942c7bb0198d3e6525cccf5f050d7e6f0a98)). 

This commit adds `'transactions'` to `option_maps`.

```
Connected to local cluster at 127.0.0.1:9042.
[ycqlsh 5.0.1 | Cassandra 3.9-SNAPSHOT | CQL spec 3.4.2 | Native protocol v4]
Use HELP for help.
ycqlsh> describe keyspaces;

system_auth  system_schema  system

ycqlsh> describe keyspace system;

CREATE KEYSPACE system WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}  AND durable_writes = true;

CREATE TABLE system.metrics (
    "node" text,
    entity_type text,
    entity_id text,
    metric text,
    ts timestamp,
    value bigint,
    details jsonb,
    PRIMARY KEY ("node", entity_type, entity_id, metric, ts)
) WITH CLUSTERING ORDER BY (entity_type ASC, entity_id ASC, metric ASC, ts DESC)
    AND default_time_to_live = 0
    AND transactions = {'enabled': 'false'};

CREATE TABLE system.local (
    key text PRIMARY KEY,
    bootstrapped text,
    broadcast_address inet,
    cluster_name text,
    cql_version text,
    data_center text,
    gossip_generation int,
    host_id uuid,
    listen_address inet,
    native_protocol_version text,
    partitioner text,
    rack text,
    release_version text,
    rpc_address inet,
    schema_version uuid,
    thrift_version text,
    tokens set<text>,
    truncated_at map<uuid, blob>
) WITH default_time_to_live = 0
    AND transactions = {'enabled': 'false'};

CREATE TABLE system.partitions (
    keyspace_name text,
    table_name text,
    start_key blob,
    end_key blob,
    id uuid,
    replica_addresses map<inet, text>,
    PRIMARY KEY (keyspace_name, table_name, start_key)
) WITH CLUSTERING ORDER BY (table_name ASC, start_key ASC)
    AND default_time_to_live = 0
    AND transactions = {'enabled': 'false'};

CREATE TABLE system.peers (
    peer inet PRIMARY KEY,
    data_center text,
    host_id uuid,
    preferred_ip inet,
    rack text,
    release_version text,
    rpc_address inet,
    schema_version uuid,
    tokens set<text>
) WITH default_time_to_live = 0
    AND transactions = {'enabled': 'false'};

CREATE TABLE system.size_estimates (
    keyspace_name text,
    table_name text,
    range_start text,
    range_end text,
    mean_partition_size bigint,
    partitions_count bigint,
    PRIMARY KEY (keyspace_name, table_name, range_start, range_end)
) WITH CLUSTERING ORDER BY (table_name ASC, range_start ASC, range_end ASC)
    AND default_time_to_live = 0
    AND transactions = {'enabled': 'false'};


ycqlsh> 
```